### PR TITLE
Fix for error in Node input

### DIFF
--- a/normal_map_to_group.py
+++ b/normal_map_to_group.py
@@ -285,7 +285,10 @@ def default_custom_nodes():
         node.inputs[4].default_value = 1.0  # Height_dy
         node.inputs[5].default_value = (0.0, 0.0, 0.0)  # Normal
     else:
-        node.inputs[3].default_value = (0.0, 0.0, 0.0)  # Normal
+        if bpy.app.version < (4, 4, 0):
+            node.inputs[3].default_value = (0.0, 0.0, 0.0)  # Normal
+        else:
+            node.inputs[4].default_value = (0.0, 0.0, 0.0)  # Normal
     # for inp in node.inputs:
     #     if inp.name not in ['Height']:
     #         node.inputs.remove(inp)


### PR DESCRIPTION
Hi!

In Blender 4.4 the Bump node as an additional input, leading to an error due to incorrect input type.

Hopefully this should fix the issue.